### PR TITLE
Enhance icon theme and add todo.md icon

### DIFF
--- a/icon_themes/monospace-icon-theme.json
+++ b/icon_themes/monospace-icon-theme.json
@@ -139,11 +139,11 @@
           "collapsed": "./icons/folder_test_light.svg",
           "expanded": "./icons/folder_test_light.svg"
         },
-        "utils": {
-          "collapsed": "./icons/folder_utils_light.svg",
-          "expanded": "./icons/folder_utils_light.svg"
-        },
         "util": {
+          "collapsed": "./icons/folder_util_light.svg",
+          "expanded": "./icons/folder_util_light.svg"
+        },
+        "utils": {
           "collapsed": "./icons/folder_util_light.svg",
           "expanded": "./icons/folder_util_light.svg"
         },
@@ -1541,11 +1541,11 @@
           "collapsed": "./icons/folder_test.svg",
           "expanded": "./icons/folder_test.svg"
         },
-        "utils": {
-          "collapsed": "./icons/folder_utils.svg",
-          "expanded": "./icons/folder_utils.svg"
-        },
         "util": {
+          "collapsed": "./icons/folder_util.svg",
+          "expanded": "./icons/folder_util.svg"
+        },
+        "utils": {
           "collapsed": "./icons/folder_util.svg",
           "expanded": "./icons/folder_util.svg"
         },


### PR DESCRIPTION
This pull request makes significant enhancements to the `monospace-icon-theme.json` icon theme (previously named `monospacel-icon-theme.json`). The main improvements include adding explicit icon mappings for many commonly used directories (both light and dark themes) and introducing a new file suffix mapping for `todo.md` files. These changes will improve the visual distinction and recognition of folders and files in supported editors.

**Icon theme improvements:**

* Added a comprehensive set of `named_directory_icons` for both light and dark themes, assigning specific icons to commonly used folders such as `.git`, `src`, `dist`, `node_modules`, `tests`, and more. This provides clearer visual cues for project structure. [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R13-R158) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R1415-R1560)

**File suffix enhancements:**

* Introduced a new file suffix mapping for `todo.md`, allowing these files to be displayed with a dedicated icon. [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26L810-R957) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26L2065-R2359)

**Other changes:**

* Renamed the icon theme file from `monospacel-icon-theme.json` to `monospace-icon-theme.json` for consistency and correctness. [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R13-R158) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26L810-R957) [[3]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R1415-R1560) [[4]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26L2065-R2359)