### PR TITLE
`node_module`s and `public` folder mappings

### DIFF
--- a/icon_themes/monospace-icon-theme.json
+++ b/icon_themes/monospace-icon-theme.json
@@ -95,6 +95,10 @@
           "collapsed": "./icons/folder_git_light.svg",
           "expanded": "./icons/folder_git_light.svg"
         },
+        "icons": {
+          "collapsed": "./icons/folder_images_light.svg",
+          "expanded": "./icons/folder_images_light.svg"
+        },
         "images": {
           "collapsed": "./icons/folder_images_light.svg",
           "expanded": "./icons/folder_images_light.svg"
@@ -1496,6 +1500,10 @@
         "git": {
           "collapsed": "./icons/folder_git.svg",
           "expanded": "./icons/folder_git.svg"
+        },
+        "icons": {
+          "collapsed": "./icons/folder_images.svg",
+          "expanded": "./icons/folder_images.svg"
         },
         "images": {
           "collapsed": "./icons/folder_images.svg",

--- a/icon_themes/monospace-icon-theme.json
+++ b/icon_themes/monospace-icon-theme.json
@@ -115,9 +115,17 @@
           "collapsed": "./icons/folder_lib_light.svg",
           "expanded": "./icons/folder_lib_light.svg"
         },
+        "node_modules": {
+          "collapsed": "./icons/folder_node_light.svg",
+          "expanded": "./icons/folder_node_light.svg"
+        },
         "pages": {
           "collapsed": "./icons/folder_pages_light.svg",
           "expanded": "./icons/folder_pages_light.svg"
+        },
+        "public": {
+          "collapsed": "./icons/folder_public_light.svg",
+          "expanded": "./icons/folder_public_light.svg"
         },
         "scripts": {
           "collapsed": "./icons/folder_scripts_light.svg",
@@ -1521,9 +1529,17 @@
           "collapsed": "./icons/folder_lib.svg",
           "expanded": "./icons/folder_lib.svg"
         },
+        "node_modules": {
+          "collapsed": "./icons/folder_node.svg",
+          "expanded": "./icons/folder_node.svg"
+        },
         "pages": {
           "collapsed": "./icons/folder_pages.svg",
           "expanded": "./icons/folder_pages.svg"
+        },
+        "public": {
+          "collapsed": "./icons/folder_public.svg",
+          "expanded": "./icons/folder_public.svg"
         },
         "scripts": {
           "collapsed": "./icons/folder_scripts.svg",


### PR DESCRIPTION
This pull request adds new folder icon mappings to the `monospace-icon-theme.json` file, improving the visual distinction for several common folders in both light and dark themes.

**New folder icon mappings:**

* Added icon mapping for the `icons` folder in both light and dark themes (`folder_images_light.svg` and `folder_images.svg`). [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R98-R101) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R1512-R1515)
* Added icon mapping for the `node_modules` folder in both light and dark themes (`folder_node_light.svg` and `folder_node.svg`). [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R118-R129) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R1532-R1543)
* Added icon mapping for the `public` folder in both light and dark themes (`folder_public_light.svg` and `folder_public.svg`). [[1]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R118-R129) [[2]](diffhunk://#diff-780a6011854ee921f69a0893fcf7eff33ec6287e9a6c8bc3088011df9f64ea26R1532-R1543)